### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-3.10.1-php-fpm.yml
+++ b/.github/workflows/docker-3.10.1-php-fpm.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cateduac/moodle
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/.github/workflows/docker-3.10.3-php-fpm-unoconv.yml
+++ b/.github/workflows/docker-3.10.3-php-fpm-unoconv.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cateduac/moodle
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/.github/workflows/docker-3.10.4-php-fpm-unoconv.yml
+++ b/.github/workflows/docker-3.10.4-php-fpm-unoconv.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cateduac/moodle
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/.github/workflows/docker-3.11-php-fpm-unoconv.yml
+++ b/.github/workflows/docker-3.11-php-fpm-unoconv.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cateduac/moodle
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/.github/workflows/docker-3.11.2-php-fpm-unoconv.yml
+++ b/.github/workflows/docker-3.11.2-php-fpm-unoconv.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cateduac/moodle
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/.github/workflows/docker-3.11.5-php-fpm-unoconv.yml
+++ b/.github/workflows/docker-3.11.5-php-fpm-unoconv.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cateduac/moodle
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/.github/workflows/docker-3.11.7-php-fpm-unoconv.yml
+++ b/.github/workflows/docker-3.11.7-php-fpm-unoconv.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cateduac/moodle
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/.github/workflows/docker-3.7.6-apache.yml
+++ b/.github/workflows/docker-3.7.6-apache.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cateduac/moodle
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/.github/workflows/docker-3.7.6-php-fpm.yml
+++ b/.github/workflows/docker-3.7.6-php-fpm.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cateduac/moodle
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/.github/workflows/docker-3.8.3-apache.yml
+++ b/.github/workflows/docker-3.8.3-apache.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cateduac/moodle
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/.github/workflows/docker-3.8.3-php-fpm.yml
+++ b/.github/workflows/docker-3.8.3-php-fpm.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cateduac/moodle
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/.github/workflows/docker-3.9.4-php-fpm.yml
+++ b/.github/workflows/docker-3.9.4-php-fpm.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cateduac/moodle
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/.github/workflows/docker-4.0.4-php-fpm-unoconv.yml
+++ b/.github/workflows/docker-4.0.4-php-fpm-unoconv.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cateduac/moodle
           username: ${{ secrets.DOCKER_HUB_USER }}

--- a/.github/workflows/docker-4.1.1-php-fpm-unoconv.yml
+++ b/.github/workflows/docker-4.1.1-php-fpm-unoconv.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: cateduac/moodle
           username: ${{ secrets.DOCKER_HUB_USER }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore